### PR TITLE
Initial commit for 0.7 update

### DIFF
--- a/basecontext.py
+++ b/basecontext.py
@@ -217,27 +217,27 @@ class APIContext :
     async def acallapi(self,url,headers=None) :
         rec = False #Used for the return - default of False means it failed.
         #header is currently only needed by twitch, where it contains the API key
-        async with self.conn.get(url,headers=headers) as resp :
-            try :
+        try :
+            async with self.conn.get(url,headers=headers) as resp :
                 if resp.status == 200 : #Success
                     buff = await resp.text()
                     #print(buff)
                     if buff :
                         rec = json.loads(buff) #Interpret the received JSON
-            #Ignore connection errors, and we can try again next update
-            except aiohttp.ClientConnectionError :
-                rec = False #Low level connection problems per aiohttp docs.
-            except aiohttp.ClientConnectorError :
-                rec = False #Also a connection problem.
-            except aiohttp.ServerDisconnectedError :
-                rec = False #Also a connection problem.
-            except aiohttp.ServerTimeoutError :
-                rec = False #Also a connection problem.
-            except asyncio.TimeoutError :
-                rec = False #Exceeded the timeout we set - 60 seconds.
-            except json.JSONDecodeError : #Error in reading JSON - bad response from server?
-                print("JSON Error in",self.name) #Log this, since it shouldn't happen.
-                rec = False #This shouldn't happen since status == 200
+        #Ignore connection errors, and we can try again next update
+        except aiohttp.ClientConnectionError :
+            rec = False #Low level connection problems per aiohttp docs.
+        except aiohttp.ClientConnectorError :
+            rec = False #Also a connection problem.
+        except aiohttp.ServerDisconnectedError :
+            rec = False #Also a connection problem.
+        except aiohttp.ServerTimeoutError :
+            rec = False #Also a connection problem.
+        except asyncio.TimeoutError :
+            rec = False #Exceeded the timeout we set - 60 seconds.
+        except json.JSONDecodeError : #Error in reading JSON - bad response from server?
+            print("JSON Error in",self.name) #Log this, since it shouldn't happen.
+            rec = False #This shouldn't happen since status == 200
         return rec
 
     #Updates parsed dict by calling the API. Generalized enough that it works for Picarto+Piczel
@@ -271,7 +271,7 @@ class APIContext :
 ##            pass #This shouldn't happen since status == 200, but ignore for now.
         buff = await self.acallapi(self.apiurl)
         if buff : #Any errors would return False instead of a buffer
-            self.parsed = {await self.getrecname(item):item for item in json.loads(buff)}
+            self.parsed = {await self.getrecname(item):item for item in buff}
             updated = True #Parse finished, we updated fine.
         if updated : #We updated fine so we need to record that
             self.lastupdate.append(updated) #Not empty means list is True, update succeeded
@@ -414,6 +414,7 @@ class APIContext :
                 #since you can always delete/edit your own stuff, but JIC.
                 pass
             #Remove the msg from the list, we won't update it anymore.
+            #This still happens for static messages, which aren't edited or removed
             try : #They might not have a message saved, ignore that
                 del self.savedmsg[server][recid]
             except KeyError :

--- a/picartoclass.py
+++ b/picartoclass.py
@@ -10,26 +10,6 @@ import urllib.request as request #Send HTTP requests - debug use only NOT IN BOT
 parsed = {} #Dict with key == 'name'
 lastupdate = [] #Did the last update succeed?
 
-#Keep a dict of channels to search for, list of servers that want that info
-#AnnounceDict
-#   |-"JazzyZ401"
-#       |JazzySpeaksThingy
-#   |-"Krypt"
-#       |-Glittershell
-#       |-PonyPervingParty
-
-#Keep a dict of servers, that holds the dict of options
-#Servers
-#   |-"JazzySpeaksThingy"
-#       |"AnnounceChannel": "#announcements"
-#       |"Listens": set()
-#       |"Users": set()
-#   |-"Glittershell"
-#       |"AnnounceChannel": "#livestream"
-#       |"Listens": set()
-#       |"Users": set()
-#       |"Here": true
-
 #Old non-async method. Kept for debugging.
 def connect() :
     global parsed
@@ -62,7 +42,7 @@ class PicartoContext(basecontext.APIContext) :
         basecontext.APIContext.__init__(self,instname)
         #Our parsed is going to be the global parsed in our module, instead of the
         #basecontext parsed. This gets shared with ALL instances of this class.
-        #Primarily this will sharing API response data with all instances.
+        #Primarily this will allow sharing API response data with all instances.
         self.parsed = parsed #Removing any of this isn't recommended.
         self.lastupdate = lastupdate #Tracks if last API update was successful.
         #Adding stuff below here is fine, obviously.

--- a/picartoclass.py
+++ b/picartoclass.py
@@ -7,7 +7,8 @@ import asyncio #Use this for sleep, not time.sleep.
 import datetime #Interpret date+time results for lastonline
 import urllib.request as request #Send HTTP requests - debug use only NOT IN BOT
 
-parsed = {} #Dict with key == 'user_name'
+parsed = {} #Dict with key == 'name'
+lastupdate = [] #Did the last update succeed?
 
 #Keep a dict of channels to search for, list of servers that want that info
 #AnnounceDict
@@ -51,70 +52,46 @@ def getchannel(channelname) :
 
 import basecontext
 class PicartoContext(basecontext.APIContext) :
-    defaultname = "picarto"
-    streamurl = "https://picarto.tv/{0}"
+    defaultname = "picarto" #This is used to name this context and is the command to call it. Must be unique.
+    streamurl = "https://picarto.tv/{0}" #URL for going to watch the stream
+    apiurl = "https://api.picarto.tv/v1/online?adult=true&gaming=true" #URL to call to find online streams
+    channelurl = "https://api.picarto.tv/v1/channel/name/{0}" #URL to call to get information on a single channel
 
     def __init__(self,instname=None) :
         #Init our base class
         basecontext.APIContext.__init__(self,instname)
-        #Our parsed is going to be the global picartoclass parsed, instead of the
+        #Our parsed is going to be the global parsed in our module, instead of the
         #basecontext parsed. This gets shared with ALL instances of this class.
-        self.parsed = parsed
-
-    #Called to update the API data by basecontext's updatetask. When it's finished
-    #parsed should have the current list of online channels.
-    async def updateparsed(self) :
-        updated = False
-        async with aiohttp.request('GET',"https://api.picarto.tv/v1/online?adult=true&gaming=true") as resp :
-            try :
-                buff = await resp.text()
-                #resp.close()
-                if buff :
-                    self.parsed = {item['name']:item for item in json.loads(buff)}
-                    updated = True
-            except aiohttp.ClientConnectionError :
-                pass #Low level connection problems per aiohttp docs. Ignore for now.
-            except aiohttp.ClientConnectorError :
-                pass #Also a connection problem. Ignore for now.
-            except json.JSONDecodeError :
-                pass #Error in reading JSON - bad response from server. Ignore for now.
-        return updated
-
-    #Gets the detailed information about a channel. Used for makedetailmsg.
-    #It returns a channel record.
-    async def agetchannel(self,channelname) :
-        rec = False
-        async with aiohttp.request('GET',"https://api.picarto.tv/v1/channel/name/" + channelname) as resp :
-            try :
-                buff = await resp.text()
-                #resp.close()
-                if buff :
-                    rec = json.loads(buff)
-            except :
-                rec = False
-        return rec
+        #Primarily this will sharing API response data with all instances.
+        self.parsed = parsed #Removing any of this isn't recommended.
+        self.lastupdate = lastupdate #Tracks if last API update was successful.
+        #Adding stuff below here is fine, obviously.
 
     async def getrecname(self,rec) :
         return rec['name']
 
-    async def makeembed(self,rec) :
-        #Simple embed is the same, we just need to add a preview image. Save code
-        myembed = await self.simpembed(rec)
+    async def makeembed(self,rec,snowflake=None,offline=False) :
+        #Simple embed is the same, we just need to add a preview image.
+        myembed = await self.simpembed(rec,snowflake,offline)
         myembed.set_image(url=rec['thumbnails']['web'])
         return myembed
 
-    async def simpembed(self,rec) :
+    async def simpembed(self,rec,snowflake=None,offline=False) :
         description = rec['title']
         value = "Multistream: No"
         if rec['multistream'] :
             value = "Multistream: Yes"
-        noprev = discord.Embed(title=rec['name'] + " has come online!",url=self.streamurl.format(rec['name']),description=description)
+        if not snowflake :
+            embtitle = rec['name'] + " has come online!"
+        else :
+            embtitle = await self.streammsg(snowflake,offline)
+        noprev = discord.Embed(title=embtitle,url=self.streamurl.format(rec['name']),description=description)
         noprev.add_field(name="Adult: " + ("Yes" if rec['adult'] else "No"),value="Viewers: " + str(rec['viewers']),inline=True)
         noprev.add_field(name=value,value="Gaming: " + ("Yes" if rec['gaming'] else "No"),inline=True)
         noprev.set_thumbnail(url="https://picarto.tv/user_data/usrimg/" + rec['name'].lower() + "/dsdefault.jpg")
         return noprev
 
-    async def makedetailembed(self,rec) :
+    async def makedetailembed(self,rec,snowflake=None,offline=False) :
         description = rec['title']
         multstring = ""
         if rec["multistream"] :

--- a/piczelclass.py
+++ b/piczelclass.py
@@ -134,5 +134,3 @@ class PiczelContext(basecontext.APIContext) :
         myembed.set_image(url=thumburl)
         myembed.set_thumbnail(url=rec['user']['avatar']['avatar']['url'])
         return myembed
-        
-        

--- a/piczelclass.py
+++ b/piczelclass.py
@@ -6,7 +6,9 @@ import discord #The discord API module. Most useful for making Embeds
 import asyncio #Use this for sleep, not time.sleep.
 import urllib.request as request #Send HTTP requests - debug use only NOT IN BOT
 
-parsed = {} #Dict with key == 'user_name'
+parsed = {} #Dict with key == 'username'
+lastupdate = [] #Did the last update succeed?
+
 apiurl = 'https://piczel.tv/api/streams/'
 offurl = 'https://piczel.tv/static'
 piczelurl = "http://piczel.tv/watch/"
@@ -39,8 +41,10 @@ def getchannel(channelname) :
 
 import basecontext
 class PiczelContext(basecontext.APIContext) :
-    defaultname = "piczel" #This is used to name this context and is the command
-    streamurl = "http://piczel.tv/watch/{0}"#Fill this with a string, gets called as self.streamurl.format(await self.getrecname(rec)) generally
+    defaultname = "piczel" #This is used to name this context and is the command to call it. Must be unique.
+    streamurl = "http://piczel.tv/watch/{0}" #URL for going to watch the stream, gets called as self.streamurl.format(await self.getrecname(rec)) generally
+    channelurl = apiurl + "{0}" #URL to call to get information on a single channel
+    apiurl = apiurl + "?&sfw=false&live_only=false&followedStreams=false" #URL to call to find online streams
 
     def __init__(self,instname=None) :
         #Init our base class
@@ -49,41 +53,25 @@ class PiczelContext(basecontext.APIContext) :
         #basecontext parsed. This gets shared with ALL instances of this class.
         #Primarily this will sharing API response data with all instances.
         self.parsed = parsed #Removing any of this isn't recommended.
-        #Adding stuff below here is fine, obviously.
-
-    #Called to update the API data by basecontext's updatetask. When it's finished
-    #parsed should have the current list of online channels.
-    async def updateparsed(self) :
-        updated = False
-        async with aiohttp.request('GET',apiurl + "?&sfw=false&live_only=false&followedStreams=false") as resp :
-            try :
-                buff = await resp.text()
-                #resp.close()
-                if buff :
-                    self.parsed = {item['username']:item for item in json.loads(buff)}
-                    updated = True
-            except aiohttp.ClientConnectionError :
-                pass #Low level connection problems per aiohttp docs. Ignore for now.
-            except aiohttp.ClientConnectorError :
-                pass #Also a connection problem. Ignore for now.
-        return updated
+        self.lastupdate = lastupdate #Tracks if last API update was successful.
+        #Adding stuff below here is fine.
 
     #Gets the detailed information about a channel. Used for makedetailmsg.
-    #It returns a channel record.
-    async def agetchannel(self,channelname) :
+    #It returns a channel record. Needs a bit of modification from the default.
+    async def agetchannel(self,channelname,headers=None) :
         rec = False
-        async with aiohttp.request('GET',apiurl + channelname) as resp :
-            try :
-                buff = await resp.text()
-                #resp.close()
-                if buff :
-                    detchan = json.loads(buff)
-                    rec = detchan['data'][0]
-                    #If user is in a multistream detchan may have multiple records - save them
-                    if rec["in_multi"] : 
-                        rec["DBMulti"] = detchan['data']
-            except :
-                rec = False
+        #We can still use the baseclass version to handle the API call
+        detchan = await basecontext.APIContext.agetchannel(self,channelname,headers)
+        try : #Now we need to get the actual channel record from the return
+            if detchan : #detchan may be False if API call errors
+                rec = detchan['data'][0] #data is an array of channels - first one is our target channel
+                #If user is in a multistream detchan may have multiple records - save them
+                if rec["in_multi"] :
+                    #The other records in data are members of a multistream with our target channel
+                    #This is useful info for the detailed embed.
+                    rec["DBMulti"] = detchan['data']
+        except Exception: #Any errors, we can't return the record.
+            rec = False
         return rec
 
     async def getrecname(self,rec) :
@@ -94,9 +82,9 @@ class PiczelContext(basecontext.APIContext) :
 
     #The embed used by the default message type. Same as the simple embed except
     #that was add on a preview of the stream.
-    async def makeembed(self,rec) :
+    async def makeembed(self,rec,snowflake=None,offline=False) :
         #Simple embed is the same, we just need to add a preview image. Save code
-        myembed = await self.simpembed(rec)
+        myembed = await self.simpembed(rec,snowflake,offline)
         thumburl = 'https://piczel.tv/static/thumbnail/stream_' + str(rec['id']) + '.jpg'
         myembed.set_image(url=thumburl) #Add your image here
         return myembed
@@ -104,18 +92,22 @@ class PiczelContext(basecontext.APIContext) :
     #The embed used by the noprev option message. This is general information
     #about the stream - just the most important bits. Users can get a more
     #detailed version using the detail command.
-    async def simpembed(self,rec) :
+    async def simpembed(self,rec,snowflake=None,offline=False) :
         description = rec['title']
         value = "Multistream: No"
         if rec['in_multi'] :
             value = "\nMultistream: Yes"
-        noprev = discord.Embed(title=rec['username'] + " has come online!",url=piczelurl + rec['username'],description=description)
+        if not snowflake :
+            embtitle = rec['username'] + " has come online!"
+        else :
+            embtitle = await self.streammsg(snowflake,offline)
+        noprev = discord.Embed(title=embtitle,url=piczelurl + rec['username'],description=description)
         noprev.add_field(name="Adult: " + ("Yes" if rec['adult'] else "No"),value="Viewers: " + str(rec['viewers']),inline=True)
         noprev.add_field(name=value,value="Private: " + ("Yes" if rec['isPrivate?'] else "No"),inline=True)
         noprev.set_thumbnail(url=rec['user']['avatar']['avatar']['url'])
         return noprev
 
-    async def makedetailembed(self,rec) :
+    async def makedetailembed(self,rec,snowflake=None,offline=False) :
         #This generates the embed to send when detailed info about a channel is
         #requested. The actual message is handled by basecontext's detailannounce
         description = rec['title']

--- a/templateclass.py
+++ b/templateclass.py
@@ -9,12 +9,15 @@ import json #Interpreting json results - updateparsed most likely needs this.
 import discord #The discord API module. Most useful for making Embeds
 import asyncio #Use this for sleep, not time.sleep.
 
-parsed = {} #Dict with key == 'user_name'
+parsed = {} #Dict with key == 'user_name', filled by basecontext.updateparsed
+lastupdate = [] #Did the last update succeed?
 
 import basecontext
 class TemplateContext(basecontext.APIContext) :
     defaultname = "template" #This is used to name this context and is the command
-    streamurl = #Fill this with a string, gets called as self.streamurl.format(await self.getrecname(rec)) generally
+    streamurl = #URL for going to watch the stream, gets called as self.streamurl.format(await self.getrecname(rec))
+    apiurl = #URL to call to update the list of online streams, used by updateparsed
+    channelurl = #URL to call to get detailed information about a specific channel, used by agetchannel
 
     def __init__(self,instname=None) :
         #Init our base class
@@ -23,15 +26,20 @@ class TemplateContext(basecontext.APIContext) :
         #basecontext parsed. This gets shared with ALL instances of this class.
         #Primarily this will sharing API response data with all instances.
         self.parsed = parsed #Removing any of this isn't recommended.
+        self.lastupdate = lastupdate #Tracks if last API update was successful.
         #Adding stuff below here is fine, obviously.
 
     #Called to update the API data by basecontext's updatetask. When it's finished
     #parsed should have the current list of online channels.
     async def updateparsed(self) :
+        #basecontexts version can handle most cases, now that it's been generalized
+        #If you don't need any special handling of the call or output, can be deleted
 
     #Gets the detailed information about a channel. Used for makedetailmsg.
     #It returns a channel record.
     async def agetchannel(self,channelname) :
+        #basecontexts version can handle most cases now that it's been generalized
+        #If you don't need any special handling of the call or output, can be deleted
 
     async def getrecname(self,rec) :
         #Should return the name of the record used to uniquely id the stream.
@@ -40,7 +48,7 @@ class TemplateContext(basecontext.APIContext) :
         return rec[=]
 
     #The embed used by the default message type. Same as the simple embed except
-    #that was add on a preview of the stream.
+    #that we add on a preview of the stream.
     async def makeembed(self,rec) :
         #You can remove this function and baseclass will just use the simpembed
         #Simple embed is the same, we just need to add a preview image. Save code

--- a/twitchclass.py
+++ b/twitchclass.py
@@ -11,6 +11,7 @@ import asyncio #Use this for sleep, not time.sleep.
 import urllib.request as request #Send HTTP requests - debug use only NOT IN BOT
 
 parsed = {} #Dict with key == 'user_name'
+lastupdate = [] #Did the last update succeed?
 
 import apitoken
 twitchheader = apitoken.twitchheader
@@ -21,7 +22,9 @@ import basecontext
 class TwitchContext(basecontext.APIContext) :
     defaultname = "twitch" #This is used to name this context and is the command
     streamurl = "https://twitch.tv/{0}"#Fill this with a string, gets called as self.streamurl.format(await self.getrecname(rec)) generally
-
+    channelurl = "https://api.twitch.tv/helix/streams?user_login={0}"
+    apiurl = 'https://api.twitch.tv/helix/streams?user_login='
+    
     def __init__(self,instname=None) :
         #Init our base class
         basecontext.APIContext.__init__(self,instname)
@@ -29,6 +32,7 @@ class TwitchContext(basecontext.APIContext) :
         #basecontext parsed. This gets shared with ALL instances of this class.
         #Primarily this will sharing API response data with all instances.
         self.parsed = parsed #Removing any of this isn't recommended.
+        self.lastupdate = lastupdate
         #Adding stuff below here is fine, obviously.
 
     #Simple generator to split list into groups no larger than 100. This is the
@@ -41,88 +45,50 @@ class TwitchContext(basecontext.APIContext) :
 
     #Called to update the API data by basecontext's updatetask. When it's finished
     #parsed should have the current list of online channels.
-    async def updateparsed2(self) :
-        #Twitch is different since you can't get all online streams - there's far
-        #too many. Instead we only grab watched channels in groups.
-        apiurl = 'https://api.twitch.tv/helix/streams?user_login='
-        found = {}
-        try :
-            for checkgroup in self.splitgroup(self.mydata['AnnounceDict']) :
-                #print("Group:",checkgroup)
-                newrequest = request.Request(apiurl + "&user_login=".join(checkgroup),headers=twitchheader)
-                newconn = request.urlopen(newrequest)
-                buff = newconn.read()
-                #print("Buff:",buff)
-                loaded = json.loads(buff)
-                found.update({item['user_name']:item for item in loaded['data']})
-        except Exception as e :
-            print("Error in twitch uparsed:",repr(e))
-        self.parsed = found
-        return True
-
-    #Called to update the API data by basecontext's updatetask. When it's finished
-    #parsed should have the current list of online channels.
     async def updateparsed(self) :
         #Twitch is different since you can't get all online streams - there's far
         #too many. Instead we only grab watched channels in groups.
-        apiurl = 'https://api.twitch.tv/helix/streams?user_login='
         found = {}
         updated = False
+        self.lastupdate.clear() #Update has not succeded.
         try :
+            #We split the streams we need to check into chunks, due to the API
+            #limit of 100 streams per call.
             for checkgroup in self.splitgroup(self.mydata['AnnounceDict']) :
-                #print("Group:",checkgroup)
-                async with aiohttp.request('GET',apiurl + "&user_login=".join(checkgroup),headers=twitchheader) as resp :
-                    buff = await resp.text()
-                    #print("Twitch Buff:",buff)
-                    loaded = json.loads(buff)
+                loaded = await self.acallapi(self.apiurl + "&user_login=".join(checkgroup),headers=twitchheader)
+                #print(loaded)
+                if loaded : #We got a response back
                     found.update({item['user_name']:item for item in loaded['data']})
+                else :
+                    raise ValueError()
             updated = True #We finished our loop so updates are complete.
-        except asyncio.CancelledError : #We're being closed, so exit out.
-            raise
-        except aiohttp.ClientConnectionError :
-            pass #Low level connection problems per aiohttp docs. Ignore for now.
-        except aiohttp.ClientConnectorError :
-            pass #Also a connection problem. Ignore for now.
-        except Exception as e :
+        except ValueError as e : #Not success, or empty buffer.
             #Updated should be False anyway, but jic
             updated = False #Errors mean bad things happened, so skip this update
-            print("Error in twitch uparsed2:",repr(e))
         if updated :
             self.parsed = found
+            self.lastupdate.append(updated) #Not empty means list is True, update succeeded
         return updated
 
     #Gets the detailed information about a channel. Used for makedetailmsg.
     #It returns a channel record.
     async def agetchanneloffline(self,channelname) :
-        try :
-            async with aiohttp.request('GET','https://api.twitch.tv/helix/users?login=' + channelname,headers=twitchheader) as resp :
-                buff = await resp.text()
-                if not buff :
-                    return False
-                detchan = json.loads(buff)
-                resp.close()
-            return detchan['data'][0]
-        except asyncio.CancelledError :
-            raise
-        except :
+        detchan = await self.acallapi('https://api.twitch.tv/helix/users?login=' + channelname,headers=twitchheader)
+        if not detchan :
             return False
+        return detchan['data'][0]
 
     #Gets the detailed information about a running stream
-    async def agetchannel(self,channelname) :
-        try :
-            async with aiohttp.request('GET','https://api.twitch.tv/helix/streams?user_login=' + channelname,headers=twitchheader) as resp :
-                buff = await resp.text()
-                if not buff :
-                    return False
-                detchan = json.loads(buff)
-                resp.close()
-            #Stream isn't online so grab the offline data.
-            if detchan['data'] :
-                return detchan['data'][0]
-            else :
-                return await self.agetchanneloffline(channelname)
-        except :
+    async def agetchannel(self,channelname,headers=None) :
+        #Call the API with our channel url, using the twitch header
+        detchan = await self.acallapi(self.channelurl.format(channelname),headers=twitchheader)
+        if not detchan :
             return False
+        #If we have a record in 'data' then the stream is online
+        if detchan['data'] :
+            return detchan['data'][0]
+        else : #Stream isn't online so grab the offline data.
+            return await self.agetchanneloffline(channelname)
 
     #Gets the name of the game with gameid. Uses a caching system to prevent
     #unneeded lookups.
@@ -131,12 +97,8 @@ class TwitchContext(basecontext.APIContext) :
         if gameid in self.mydata['Games'] :
             return self.mydata['Games'][gameid]
         try :
-            async with aiohttp.request('GET','https://api.twitch.tv/helix/games?id=' + gameid,headers=twitchheader) as resp :
-                buff = await resp.text()
-                if not buff :
-                    return False
-                detchan = json.loads(buff)['data'][0]
-                resp.close()
+            buff = await self.acallapi('https://api.twitch.tv/helix/games?id=' + gameid,headers=twitchheader)
+            detchan = buff['data'][0]
             self.mydata['Games'][gameid] = detchan['name']
             return detchan['name']
         except Exception as e:
@@ -156,26 +118,32 @@ class TwitchContext(basecontext.APIContext) :
 
     #The embed used by the default message type. Same as the simple embed except
     #that was add on a preview of the stream.
-    async def makeembed(self,rec) :
+    async def makeembed(self,rec,snowflake=None,offline=False) :
         #You can remove this function and baseclass will just use the simpembed
         #Simple embed is the same, we just need to add a preview image. Save code
-        myembed = await self.simpembed(rec)
+        myembed = await self.simpembed(rec,snowflake,offline)
         myembed.set_image(url=rec['thumbnail_url'].replace("{width}","848").replace("{height}","480")) #Add your image here
         return myembed
     
     #The embed used by the noprev option message. This is general information
     #about the stream - just the most important bits. Users can get a more
     #detailed version using the detail command.
-    async def simpembed(self,rec) :
+    async def simpembed(self,rec,snowflake=None,offline=False) :
         description = rec['title']
-        noprev = discord.Embed(title=rec['user_name'] + " has come online!",url="https://twitch.tv/" + rec['user_name'],description=description)
+        if not snowflake :
+            embtitle = rec['user_name'] + " has come online!"
+        else :
+            embtitle = await self.streammsg(snowflake,offline)
+        noprev = discord.Embed(title=embtitle,url="https://twitch.tv/" + rec['user_name'],description=description)
         noprev.add_field(name="Game: " + await self.getgame(rec['game_id']),value="Viewers: " + str(rec['viewer_count']),inline=True)
         return noprev
 
-    async def makedetailembed(self,rec) :
+    async def makedetailembed(self,rec,snowflake=None,offline=False) :
         #This generates the embed to send when detailed info about a channel is
         #requested. The actual message is handled by basecontext's detailannounce
         myembed = None
+        #This is more complicated since there is a different record type needed
+        #if the stream is offline, than if it is online.
         if 'user_id' in rec : #user_id field is only on streams, not users
             description = rec['title']
             myembed = discord.Embed(title=rec['user_name'] + " is online!",url="https://twitch.tv/" + rec['user_name'],description=description)

--- a/twitchclass.py
+++ b/twitchclass.py
@@ -76,7 +76,9 @@ class TwitchContext(basecontext.APIContext) :
         detchan = await self.acallapi('https://api.twitch.tv/helix/users?login=' + channelname,headers=twitchheader)
         if not detchan :
             return False
-        return detchan['data'][0]
+        if detchan['data'] :
+            return detchan['data'][0]
+        return False
 
     #Gets the detailed information about a running stream
     async def agetchannel(self,channelname,headers=None) :
@@ -156,5 +158,3 @@ class TwitchContext(basecontext.APIContext) :
             myembed.add_field(name="Viewers:",value=rec['view_count'])
             myembed.set_thumbnail(url=rec['profile_image_url'])
         return myembed
-        
-        


### PR DESCRIPTION
Quitting using the debug quit command now exits with status code 42, to allow for checking of intentional stoppage.
Updates before declaring a stream offline moved to variable, as it's used in multiple places now.
API based modules now track if the last API update succeeded. Failure will be noted in the list command.
API modules all share a ClientSession instance.
API calls have more stringent timeouts for server responses.
Added acallapi, async function to get the given URL, with optional headers. This is used to centralize API handling.
  All API calls in APIContext, Picartoclass, Piczelclass, and Twitchclass use acallapi now.
updateparsed added to APIContext, used by Picarto+Piczel. Twitch still overrides.
agetchannel added to APIContext, and result modified by subclasses as necessary.
Added stream length to edited announcement messages.